### PR TITLE
Fix hedgedoc register and login

### DIFF
--- a/ctfpad/models.py
+++ b/ctfpad/models.py
@@ -121,7 +121,7 @@ class Member(TimeStampedModel):
 
     @property
     def hedgedoc_username(self):
-        return f"{self.username}@ctfpad"
+        return f"{self.username}@ctfpad.localdomain"
 
     def save(self):
         if not self.hedgedoc_password:

--- a/ctfpad/templates/ctfpad/challenges/detail.html
+++ b/ctfpad/templates/ctfpad/challenges/detail.html
@@ -8,6 +8,7 @@
 
 {% if request.user.member.hedgedoc_password %}
 <script>
+document.addEventListener('DOMContentLoaded', function() {
     fetch("{{hedgedoc_url}}/login", {
       method: 'POST',
       mode: 'no-cors',
@@ -15,7 +16,9 @@
       credentials: 'include',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded'},
       body: "email={{request.user.member.hedgedoc_username}}&password={{request.user.member.hedgedoc_password}}"
-    });
+    }).then(data => { document.getElementById("note_frame").src = "{{ challenge.note_url }}"; });
+});
+
 </script>
 {% endif %}
 
@@ -132,10 +135,10 @@
 
             <div class="embed-responsive embed-responsive-16by9">
                 <iframe
+                id="note_frame"
                 class="embed-responsive-item"
                 width="100%"
                 height="500"
-                src="{{ challenge.note_url }}"
                 frameborder="0"
                 >
                 </iframe>

--- a/ctfpad/views/__init__.py
+++ b/ctfpad/views/__init__.py
@@ -1,7 +1,6 @@
 from django.urls.base import reverse
 from ctfpad.forms import CtfCreateUpdateForm
 from ctfpad.decorators import only_if_authenticated_user
-from ctftools.settings import HEDGEDOC_URL
 from django.http.request import HttpRequest
 from django.http.response import HttpResponse
 from django.shortcuts import redirect, render
@@ -68,7 +67,6 @@ def dashboard(request: HttpRequest) -> HttpResponse:
         "current_ctfs": current_ctfs,
         "next_ctf": next_ctf,
         "quick_add_form": quick_add_form,
-        "hedgedoc_url": HEDGEDOC_URL,
     }
     return render(request, "ctfpad/dashboard/dashboard.html", context)
 

--- a/ctfpad/views/challenges.py
+++ b/ctfpad/views/challenges.py
@@ -11,6 +11,7 @@ from ctfpad.forms import (
     ChallengeFileCreateForm,
 )
 from ctfpad.models import Challenge, Ctf
+from ctftools.settings import HEDGEDOC_URL
 
 
 
@@ -67,6 +68,7 @@ class ChallengeDetailView(LoginRequiredMixin, DetailView):
     extra_context = {
         "flag_form": ChallengeSetFlagForm(),
         "file_upload_form": ChallengeFileCreateForm(),
+        "hedgedoc_url": HEDGEDOC_URL,
     }
 
     # def get_context_data(self, **kwargs):


### PR DESCRIPTION
- registering a hedgedoc account is now working -> the email address must have a fqdn
- the hidden hedgedoc login is now working -> just needed to wait for the `fetch()` call to complete before loading the note iframe