### PR TITLE
changed Dockerfile to execute docker-entrypoint.sh without chmod +x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,5 @@ RUN \
 
 
 COPY . .
-RUN chmod +x /code/docker-entrypoint.sh
 
-ENTRYPOINT ["/code/docker-entrypoint.sh"]
+ENTRYPOINT ["bash", "/code/docker-entrypoint.sh"]


### PR DESCRIPTION
This is really just to make the dev env work straight out of the box. With the below `docker-compose.yml` (note the new `build` and `volumes` directives), code changes are live but you'd still need to `chmod +x docker-entrypoint.sh` manually.
```
  ctfpad:
    #build: https://github.com/hugsy/ctfpad.git#main
    build:
      context: ../ctfpad.git
    volumes:
      - ../ctfpad.git:/code
    command: python manage.py runserver 0.0.0.0:8000
```
Anyways, thought you may find this helpful.