### PR TITLE
use CTFTime URL to pull CTF info and include the currently running CTFs to the Import listing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.vscode
+.vscode/
+env/
 **/__pycache__/
 *.pyc
 *.pyo

--- a/ctfpad/helpers.py
+++ b/ctfpad/helpers.py
@@ -104,20 +104,17 @@ def ctftime_parse_date(date: str) -> datetime:
 
 
 @lru_cache(maxsize=128)
-def ctftime_fetch_running_ctf_data() -> list:
+def ctftime_fetch_running_ctf_data(limit=100) -> list:
     """Retrieve the currently running CTFs from CTFTime API. I couldn't do this by only using the CTFTime API.
 
     Returns:
         list: JSON output from CTFTime
     """
     try:
-        # retrieve CTFs that are supposed to start and finish within a 14-day window
-        res = requests.get(f"{CTFTIME_API_EVENTS_URL}?limit=100&start={time()-(3600*24*7):.0f}&finish={time()+(3600*24*7):.0f}",
+        res = requests.get(f"{CTFTIME_API_EVENTS_URL}?limit={limit}&start={time()-(3600*24*7):.0f}&finish={time()+(3600*24*7):.0f}",
             headers={"user-agent": CTFTIME_USER_AGENT})
         if res.status_code != requests.codes.ok:
             raise RuntimeError(f"CTFTime service returned HTTP code {res.status_code} (expected {requests.codes.ok}): {res.reason}")
-
-        # only keep CTFs that have already started and not yet finished
         result = []
         for ctf in res.json():
             start, finish, now = ctftime_parse_date(ctf["start"]), ctftime_parse_date(ctf["finish"]), now

--- a/ctfpad/templates/ctfpad/ctfs/create.html
+++ b/ctfpad/templates/ctfpad/ctfs/create.html
@@ -12,7 +12,7 @@
     <div class="card" style="width: 35rem;">
         <div class="card-header">
             <h5 class="card-title">
-                {% if form.name.value %}
+                {% if form.instance.creation_time %}
                 <p class="card-header-title">Updating CTF {{form.name.value}}</p>
                 {% else %}
                 <p class="card-header-title">New CTF</p>
@@ -133,7 +133,7 @@
 
                 <div class="card-footer text-muted">
                     <div class="control card-footer-item">
-                        {% if form.name.value %}
+                        {% if form.instance.creation_time %}
                         <button type="button" class="btn-primary btn-sm btn-block" onclick="this.form.submit();">Update CTF</button>
                         {% else %}
                         <button type="button" class="btn-primary btn-sm btn-block" onclick="this.form.submit();">Create CTF</button>

--- a/ctfpad/templates/ctfpad/ctfs/list_ctftime_ctfs.html
+++ b/ctfpad/templates/ctfpad/ctfs/list_ctftime_ctfs.html
@@ -19,7 +19,7 @@
                 </td>
                 <td>{{ctf.start}}</td>
                 <td>{{ctf.finish}}</td>
-                <td><a class="btn btn-sm btn-warning" href="{% url 'ctfpad:ctfs-import' %}?ctf_ctftime_id={{ctf.id|urlencode}}&ctf_name={{ctf.title|urlencode}}&ctf_start={{ctf.start|urlencode}}&ctf_finish={{ctf.finish|urlencode}}&ctf_url={{ctf.url|urlencode}}&ctf_description={{ctf.description|urlencode}}">Import</a></td>
+                <td><a class="btn btn-sm btn-warning" href="{% url 'ctfpad:ctfs-import' %}?url={{ctf.ctftime_url|urlencode}}">Import</a></td>
             </tr>
             {% endfor %}
             </tbody>

--- a/ctfpad/templates/snippets/quick_add_form.html
+++ b/ctfpad/templates/snippets/quick_add_form.html
@@ -8,8 +8,7 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
-            <form method="POST" action="{% url 'ctfpad:ctfs-create' %}">
-            {% csrf_token %}
+            <form method="GET" action="{% url 'ctfpad:ctfs-import' %}">
                 <div class="modal-body">
                     <div class="form-group">
                         <div class="input-group mb-3">
@@ -24,7 +23,7 @@
                         <div class="input-group-append">
                             <span class="input-group-text"><i class="fas fa-link"></i></span>
                         </div>
-                        <input id=id_url name="url" class="form-control" type="text" placeholder="URL (opt.)...">
+                        <input id=id_url name="url" class="form-control" type="text" placeholder="URL (optional)...">
                     </div>
                 </div>
                 <div class="modal-footer">

--- a/ctftools/settings.py
+++ b/ctftools/settings.py
@@ -90,8 +90,8 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME':     os.getenv("CTFPAD_DB_NAME") or 'ctfpad',
-        'USER':     os.getenv("CTFPAD_DB_USER") or 'postgres',
-        'PASSWORD': os.getenv("CTFPAD_DB_PASSWORD") or 'shu2aem8DahJ4coubaquaengooqu5nae',
+        'USER':     os.getenv("CTFPAD_DB_USER") or 'ctfpad',
+        'PASSWORD': os.getenv("CTFPAD_DB_PASSWORD") or 'tookahlaiphee2KieTeeg5ooxutang4o',
         'HOST':     os.getenv("CTFPAD_DB_HOST") or 'localhost',
         'PORT':     os.getenv("CTFPAD_DB_PORT") or '5432',
     }
@@ -152,7 +152,9 @@ USERS_FILE_ROOT = MEDIA_ROOT / USERS_FILE_PATH
 
 HEDGEDOC_URL = os.getenv("HEDGEDOC_URL") or 'http://localhost:3000'
 
+CTFTIME_URL = "https://ctftime.org"
 CTFTIME_API_EVENTS_URL = "https://ctftime.org/api/v1/events/"
+CTFTIME_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64; rv:12.0) Gecko/20100101 Firefox/12.0"
 
 LOGIN_REDIRECT_URL = "ctfpad:dashboard"
 FILE_UPLOAD_MAX_MEMORY_SIZE = 2 * 1024 * 1024
@@ -162,6 +164,5 @@ FIRST_DAY_OF_WEEK = 1
 SHORT_DATE_FORMAT = 'Y-m-d'
 SHORT_DATETIME_FORMAT = 'Y-m-d P'
 
-CTFTIME_URL = "https://ctftime.org"
 CTFPAD_DEFAULT_CTF_LOGO = "blank-ctf.png"
-CTPAD_ACCEPTED_IMAGE_EXTENSIONS = (".png", ".jpg", ".gif", ".bmp")
+CTFPAD_ACCEPTED_IMAGE_EXTENSIONS = (".png", ".jpg", ".gif", ".bmp")


### PR DESCRIPTION
Sorry I couldn't break this up into 2 PRs. Two new improvements:
- the "Quick Add CTF" snippet now simply redirects to `/ctfs/import?url=..&name=..`, the Import view will pull all the info from the CTFTime API if the user provided a CTFTime URL otherwise the values are pre-filled into the CTF Create page as-is.
- the `Import from CTFTime` page now also lists the currently running CTFs