### PR TITLE
use hedgedoc image and fix issues with non default CMD_DOMAIN

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,10 +22,10 @@ services:
 
 
   hedgedoc:
-    image: quay.io/codimd/server:1.6.0
+    image: quay.io/hedgedoc/hedgedoc:1.6.0
     environment:
       - CMD_DB_URL=postgres://ctfpad:tookahlaiphee2KieTeeg5ooxutang4o@db:5432/ctfpad    # Change here
-      - CMD_DOMAIN=my.domain.com                                                        # Change here
+      - CMD_DOMAIN=localhost                                                            # Change here
       - CMD_PORT=3000                                                                   # Change here
       - CMD_COOKIE_POLICY=none
       - CMD_ALLOW_ANONYMOUS=false
@@ -43,7 +43,7 @@ services:
     build: https://github.com/hugsy/ctfpad.git#master
     command: python manage.py runserver 0.0.0.0:8000
     environment:
-      - HEDGEDOC_URL=http://localhost:3000                  # Change here to your server public IP / FQDN
+      - HEDGEDOC_URL=http://hedgedoc:3000                   # Change here to your server public IP / FQDN
       - CTFPAD_HOSTNAME=localhost                           # Change here to your server public IP / FQDN
       - CTFPAD_DB_NAME=ctfpad                               # (opt.) Change here
       - CTFPAD_DB_USER=ctfpad                               # (opt.) Change here

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     build: https://github.com/hugsy/ctfpad.git#master
     command: python manage.py runserver 0.0.0.0:8000
     environment:
-      - HEDGEDOC_URL=http://hedgedoc:3000                   # Change here to your server public IP / FQDN
+      - HEDGEDOC_URL=http://localhost:3000                  # Change here to your server public IP / FQDN
       - CTFPAD_HOSTNAME=localhost                           # Change here to your server public IP / FQDN
       - CTFPAD_DB_NAME=ctfpad                               # (opt.) Change here
       - CTFPAD_DB_USER=ctfpad                               # (opt.) Change here


### PR DESCRIPTION
The docker-compose now works out of the box. The hedgedoc notepad iframe wasnt displaying properly with `CMD_DOMAIN=my.domain.com` on my laptop, no idea why.