### PR TITLE
Show scored percentage instead of points

### DIFF
--- a/ctfpad/templates/ctfpad/stats/rank.html
+++ b/ctfpad/templates/ctfpad/stats/rank.html
@@ -70,7 +70,7 @@
                 <tr>
                     <th scope="col">Rank</th>
                     <th scope="col">Member</th>
-                    <th scope="col">Points scored</th>
+                    <th scope="col">Scored %</th>
                     <th scope="col">Best category</th>
                 </tr>
                 </thead>
@@ -79,8 +79,8 @@
                     <tr>
                         <th scope="row">{{ forloop.counter | ordinal }}</th>
                         <td>{{ member.username }}</td>
-                        <td>{{ member.total_points_scored }}</td>
-                        <td>{{ member.best_category | upper }}</td>
+                        <td>{{ member.total_scored_percent }}</td>
+                        <td>{{ member.best_category | lower }}</td>
                     </tr>
                     {% endfor %}
                 </tbody>

--- a/ctfpad/views/__init__.py
+++ b/ctfpad/views/__init__.py
@@ -94,7 +94,7 @@ def generate_stats(request: HttpRequest) -> HttpResponse:
     # ranking
     rank = sorted(
         Member.objects.all(),
-        key=lambda x: x.total_points_scored,
+        key=lambda x: x.total_scored_percent,
         reverse=True
     )
 


### PR DESCRIPTION
During a CTF, each player scores a % of the total team points. So players should be ranked by how much percentage they score across all public CTFs. I didn't bother with the ctftime weight but maybe this could be taken into consideration in the future.

Also the category name looks better in lowercase IMO :)