### PR TITLE
use hedgedoc container hostname if default URL is not accessible

### DIFF
--- a/ctfpad/helpers.py
+++ b/ctfpad/helpers.py
@@ -20,10 +20,11 @@ from ctftools.settings import (
     EMAIL_HOST, EMAIL_HOST_USER, EMAIL_HOST_PASSWORD,
 )
 
-
+@lru_cache(maxsize=1)
 def which_hedgedoc() -> str:
     """Returns the docker container hostname if the default URL from the config is not accessible.
-    This is so that people can try ctfpad out locally without making any changes to the config.
+    This is so that ctfpad works out of the box with `docker-compose up` as most people wanting to
+    trial it out won't bother changing the default values with public FQDN/IPs.
 
     Returns:
         str: the base HedgeDoc URL

--- a/ctfpad/helpers.py
+++ b/ctfpad/helpers.py
@@ -21,6 +21,21 @@ from ctftools.settings import (
 )
 
 
+def which_hedgedoc() -> str:
+    """Returns the docker container hostname if the default URL from the config is not accessible.
+    This is so that people can try ctfpad out locally without making any changes to the config.
+
+    Returns:
+        str: the base HedgeDoc URL
+    """
+    try:
+        requests.get(HEDGEDOC_URL)
+    except:
+        if HEDGEDOC_URL == 'http://localhost:3000':
+            return 'http://hedgedoc:3000'
+    return HEDGEDOC_URL
+
+
 def register_new_hedgedoc_user(username: str, password: str) -> bool:
     """Register the member in hedgedoc. If fail, the member will be
     seen as anonymous.
@@ -33,7 +48,7 @@ def register_new_hedgedoc_user(username: str, password: str) -> bool:
         bool: if the register action succeeded, returns True; False in any other cases
     """
     res = requests.post(
-        f'{HEDGEDOC_URL}/register',
+        which_hedgedoc() + '/register',
         data={'email': username, 'password': password},
         allow_redirects = False
     )


### PR DESCRIPTION
My humble suggestion so that ctfpad works out of the box after a simple `git clone ..; docker-compose up`.
Note that:
- it is only if `http://localhost:3000` is down that we sub it for `http://hedgedoc:3000`
- so if `HEDGEDOC_URL` was changed and is not accessible, then the user will get the right error message referencing the URL they wrongly configured