### PR TITLE
Fix iframe saving to history

### DIFF
--- a/ctfpad/templates/ctfpad/challenges/detail.html
+++ b/ctfpad/templates/ctfpad/challenges/detail.html
@@ -17,7 +17,9 @@ document.addEventListener('DOMContentLoaded', function() {
       credentials: 'include',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded'},
       body: "email={{request.user.member.hedgedoc_username}}&password={{request.user.member.hedgedoc_password}}"
-    }).then(data => { document.getElementById("note_frame").src = "{{ challenge.note_url }}"; });
+    }).then(data => {
+        document.getElementById("note_frame").contentWindow.location.replace("{{ challenge.note_url }}#");
+    });
 });
 </script>
 {% endif %}

--- a/ctfpad/templates/ctfpad/ctfs/detail_notes.html
+++ b/ctfpad/templates/ctfpad/ctfs/detail_notes.html
@@ -8,7 +8,10 @@ document.addEventListener('DOMContentLoaded', function() {
       credentials: 'include',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded'},
       body: "email={{request.user.member.hedgedoc_username}}&password={{request.user.member.hedgedoc_password}}"
-    }).then(data => { document.getElementById("note_frame").src = "{{ ctf.note_url }}"; });
+    }).then(data => {
+        document.getElementById("note_frame").contentWindow.location.replace("{{ ctf.note_url }}#");
+    });
+
 });
 </script>
 {% endif %}


### PR DESCRIPTION
The hedgedoc iframe adds entries to the browser's history which prevents the user from using the Back button to navigate back to the previous page.

This is a known annoyance with iframes and the solution to prevent an iframe from interfering with the browser's history is to access the iframe's content window directly and use the frame's `location.replace()` function to update the location. There are plenty of posts covering this but this one is pretty spot on: https://stackoverflow.com/questions/821359/reload-an-iframe-without-adding-to-the-history

Also yes the trailing `#` matters :)