### PR TITLE
List CTFs by start_date desc

### DIFF
--- a/ctfpad/views/__init__.py
+++ b/ctfpad/views/__init__.py
@@ -57,7 +57,7 @@ def dashboard(request: HttpRequest) -> HttpResponse:
         members = Member.objects.filter( selected_ctf = member.selected_ctf )
     else:
         members = Member.objects.all()
-    latest_ctfs = member.ctfs.order_by("-last_modification_time")
+    latest_ctfs = member.ctfs.order_by("-start_date")
     now = datetime.datetime.now()
     nb_ctf_played = member.ctfs.count()
     current_ctfs = member.public_ctfs.filter(

--- a/ctfpad/views/ctfs.py
+++ b/ctfpad/views/ctfs.py
@@ -39,7 +39,7 @@ class CtfListView(LoginRequiredMixin, MembersOnlyMixin, ListView):
 
     def get_queryset(self):
         qs = super(CtfListView, self).get_queryset()
-        return qs.filter( Q(visibility = "public" ) | Q(created_by = self.request.user.member ) )
+        return qs.filter( Q(visibility = "public" ) | Q(created_by = self.request.user.member ) ).order_by('-start_date')
 
 
 class CtfCreateView(LoginRequiredMixin, MembersOnlyMixin, SuccessMessageMixin, CreateView):


### PR DESCRIPTION
CTFs used to not be sorted at all under `/ctfs`/ and used to be sorted by `modification_time` under `/dashboard/`. When playing 2 or more CTFs on the same weekend, it makes it easier to switch between them if they're sorted by `start_date` IMO.