### PR TITLE
Show members working on private CTFs

### DIFF
--- a/ctfpad/models.py
+++ b/ctfpad/models.py
@@ -161,6 +161,8 @@ class Ctf(TimeStampedModel):
 
     @property
     def is_running(self):
+        if self.is_permanent:
+            return True
         now = datetime.now()
         return self.start_date <= now < self.end_date
 

--- a/ctfpad/templates/ctfpad/dashboard/dashboard.html
+++ b/ctfpad/templates/ctfpad/dashboard/dashboard.html
@@ -40,7 +40,7 @@
 							{% if member.selected_ctf.is_public %}
 							{{member.selected_ctf}}
 							{% else %}
-							<i>(private)</i>
+							<i>{{member.selected_ctf}} (private)</i>
 							{% endif %}
 						</td>
 					</tr>


### PR DESCRIPTION
Now shows who's playing private CTFs (like Pico) under the Team Activity section.

Does "private" just mean it is a permanent CTF ? I'm not 100% clear on what private means, maybe there are some changes/refactoring we can make to clarify this feature.