### PR TITLE
Now works out of the box with hedgedoc 1.7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBUG 0
 ENV CTFPAD_HOSTNAME localhost                # change here if publicly exposed
 ENV HEDGEDOC_URL http://hedgedoc:3000        # change here if publicly exposed
 ENV WHITEBOARD_URL http://whiteboard:8080    # change here if publicly exposed
-RUN mkdir /code
+
 WORKDIR /code
 COPY requirements.txt .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - CMD_DB_URL=postgres://ctfpad:tookahlaiphee2KieTeeg5ooxutang4o@db:5432/ctfpad    # Change here
       - CMD_DOMAIN=localhost                                                            # Change here to your server public IP / FQDN
       - CMD_PORT=3000                                                                   # Change here
-      - CMD_COOKIE_POLICY=none
+      - CMD_URL_ADDPORT=true
       - CMD_ALLOW_ANONYMOUS=false
       - CMD_ALLOW_FREEURL=true
       - CMD_IMAGE_UPLOAD_TYPE=filesystem


### PR DESCRIPTION
1. Now works out of the box with a simple `docker-compose up -d`. Looks like since upgrading from hedgedoc 1.6.0 to 1.7.2 we now need to explicitly set `CMD_URL_ADDPORT=true` otherwise hedgework won't work because it will try to pull .js files from 80/tcp
2. Don't need to `mkdir` because `WORKDIR` does it for us