### PR TITLE
Do not show finished CTFs in the Import from ctftime page

### DIFF
--- a/ctfpad/views/ctfs.py
+++ b/ctfpad/views/ctfs.py
@@ -33,9 +33,13 @@ class CtfListView(LoginRequiredMixin, MembersOnlyMixin, ListView):
     redirect_field_name = "redirect_to"
     paginate_by = 25
     ordering = ["-id"]
-    extra_context = {
-        "ctftime_ctfs": ctftime_ctfs(running=True, future=True),
-    }
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx |= {
+            "ctftime_ctfs": ctftime_ctfs(running=True, future=True)
+        }
+        return ctx
 
     def get_queryset(self):
         qs = super(CtfListView, self).get_queryset()


### PR DESCRIPTION
We tried to fix this before with my PR #16 and then later in your commit 221f77f but finished CTFs are still showing.

It is not a cache pb, it is because of `extra_context` being a static class member at https://github.com/hugsy/ctfpad/blob/master/ctfpad/views/ctfs.py#L36 

So now that's fixed, i've brought back `@lru_cache` hope that's ok. I've also removed the catch-all `except`. Let me know.