### PR TITLE
Fix best_category()

### DIFF
--- a/ctfpad/models.py
+++ b/ctfpad/models.py
@@ -308,9 +308,9 @@ class Member(TimeStampedModel):
         best_categories_by_point = self.solved_public_challenges.values(
             "category__name"
         ).annotate(
-            dcount=Sum("points")
+            total_points=Sum("points")
         ).order_by(
-            "-points"
+            "-total_points"
         )
         if best_categories_by_point.count() == 0:
             return ""
@@ -465,15 +465,12 @@ class Challenge(TimeStampedModel):
         if self.flag_tracker.has_changed("flag"):
             self.status = "solved"
             self.solvers.add( self.last_update_by )
-            self.solved_time = datetime.now()
 
         super(Challenge, self).save()
         return
 
-
     def get_absolute_url(self):
         return reverse('ctfpad:challenges-detail', args=[str(self.id), ])
-
 
 
 class ChallengeFile(TimeStampedModel):


### PR DESCRIPTION
The best category was incorrectly showing based on the solved challenge carrying the most points.

I noticed this bug because my best category is web but it was showing network. This was because i had recently scored a 1000 points networking challenge, which is more than any other challenge i've ever solved.

It now shows the correct best category based on the highest total points scored.

Also we don't need to touch `self.solved_time` because it gets updated automatically as a `MonitorField`.