### PR TITLE
Beautify with automatic avatars

### DIFF
--- a/ctfpad/templates/ctfpad/navbar.html
+++ b/ctfpad/templates/ctfpad/navbar.html
@@ -15,9 +15,7 @@
                     {% if request.user.is_authenticated %}
                     &nbsp;
                     <strong>{{request.user.member.username}}</strong>
-                    {% if request.user.member.avatar %}
-                    &nbsp;<img src="{{request.user.member.avatar.url}}" alt="avatar" class="rounded-circle" width="25px" height="25">
-                    {% endif %}
+                    &nbsp;<img src="{{request.user.member.avatar_url}}" alt="avatar" class="rounded-circle" width="25px" height="25">
                     {% if request.user.member.is_guest %}<strong>(guest)</strong>{% endif %}
                     {% endif %}
                 </a>

--- a/ctfpad/templates/ctfpad/stats/rank.html
+++ b/ctfpad/templates/ctfpad/stats/rank.html
@@ -6,16 +6,11 @@
     <div class="col-sm">
         <div id="podium">
             <div class="card card-body">
-                <h5>Podium</h5>
+                <h5>All Time Ranking</h5>
                 <div id="podium-box" class="row" style="height: 250px">
                     <div class="col-md-4 step-container m-0 p-0">
                         <div>
-                            {% if ranked_members.1.avatar %}
-                            <img width="100px" height="100px" src="{{ranked_members.1.avatar.url}}" alt="2nd" class="rounded-circle">
-                            {% else %}
-                            <img width="100px" height="100px" src="{% static '/images/blank-avatar.png' %}" alt="2nd" class="rounded-circle">
-                            {% endif %}
-                            {{ranked_members.1}}
+                            <img width="100px" height="100px" src="{{ranked_members.1.avatar_url}}" title="{{ranked_members.1.username}}" alt="2nd" class="rounded-circle">
                         </div>
                         <div id="second-step" class="bg-blue step centerBoth podium-number">
                             2
@@ -23,12 +18,7 @@
                     </div>
                     <div class="col-md-4 step-container m-0 p-0">
                         <div>
-                            {% if ranked_members.0.avatar %}
-                            <img width="100px" height="100px" src="{{ranked_members.0.avatar.url}}" alt="1st" class="rounded-circle">
-                            {% else %}
-                            <img width="100px" height="100px" src="{% static '/images/blank-avatar.png' %}" alt="1st" class="rounded-circle">
-                            {% endif %}
-                            {{ranked_members.0}}
+                            <img width="100px" height="100px" src="{{ranked_members.0.avatar_url}}" title="{{ranked_members.0.username}}" alt="1st" class="rounded-circle">
                         </div>
                         <div id="first-step" class="bg-blue step centerBoth podium-number">
                             1
@@ -36,42 +26,34 @@
                     </div>
                     <div class="col-md-4 step-container m-0 p-0">
                         <div>
-                            {% if ranked_members.2.avatar %}
-                            <img width="100px" height="100px" src="{{ranked_members.2.avatar.url}}" alt="3rd" class="rounded-circle">
-                            {% else %}
-                            <img width="100px" height="100px" src="{% static '/images/blank-avatar.png' %}" alt="3rd" class="rounded-circle">
-                            {% endif %}
-                            {{ranked_members.2}}
+                            <img width="100px" height="100px" src="{{ranked_members.2.avatar_url}}" title="{{ranked_members.2.username}}" alt="3rd" class="rounded-circle">
                         </div>
                         <div id="third-step" class="bg-blue step centerBoth podium-number">
                             3
                         </div>
                     </div>
                 </div>
-            </div>
-        </div>
-        <div class="card card-body">
-            <h5>Ranking</h5>
-            <table class="table table-hover">
-                <thead>
-                <tr>
-                    <th scope="col">Rank</th>
-                    <th scope="col">Member</th>
-                    <th scope="col">Scored %</th>
-                    <th scope="col">Best category</th>
-                </tr>
-                </thead>
-                <tbody>
-                    {% for member in ranked_members %}
+                <table class="table table-hover">
+                    <thead>
                     <tr>
-                        <th scope="row">{{ forloop.counter | ordinal }}</th>
-                        <td>{{ member.username }}</td>
-                        <td>{{ member.total_scored_percent }}</td>
-                        <td>{{ member.best_category | lower }}</td>
+                        <th scope="col">Rank</th>
+                        <th scope="col">Member</th>
+                        <th scope="col">Scored %</th>
+                        <th scope="col">Best category</th>
                     </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+                    </thead>
+                    <tbody>
+                        {% for member in ranked_members %}
+                        <tr>
+                            <th scope="row">{{ forloop.counter | ordinal }}</th>
+                            <td>{{ member.username }}</td>
+                            <td>{{ member.total_scored_percent }}</td>
+                            <td>{{ member.best_category | lower }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 
@@ -92,9 +74,16 @@
                 <tbody>
                     {% for ctf, ranked in ranked_history %}
                     <tr>
-                        <th scope="row">{{ ctf }}</th>
-                        {% for score in ranked %}
-                        <td>{{ score }}</td>
+                        <th scope="row" style="vertical-align: middle;">{{ctf.name}}</th>
+                        {% for member in ranked %}
+                        <td style="vertical-align: middle;">
+                            {% if member %}
+                                <img width="30px" height="30px" src="{{member.avatar_url}}" title="{{member.username}}" class="rounded-circle">
+                                &nbsp;{{member.scored_percent}}&#x25;
+                            {% else %}
+                                &nbsp;
+                            {% endif %}
+                        </td>
                         {% endfor %}
                     </tr>
                     {% endfor %}

--- a/ctfpad/templates/ctfpad/stats/rank.html
+++ b/ctfpad/templates/ctfpad/stats/rank.html
@@ -78,7 +78,7 @@
                         {% for member in ranked %}
                         <td style="vertical-align: middle;">
                             {% if member %}
-                                <img width="30px" height="30px" src="{{member.avatar_url}}" title="{{member.username}}" class="rounded-circle">
+                                <img width="30px" height="30px" src="{{member.avatar_url}}" title="{{member.username}}" alt="avatar" class="rounded-circle">
                                 &nbsp;{{member.scored_percent}}&#x25;
                             {% else %}
                                 &nbsp;

--- a/ctfpad/templates/ctfpad/stats/team.html
+++ b/ctfpad/templates/ctfpad/stats/team.html
@@ -84,7 +84,7 @@
                 {% for member in team.members %}
                 <tr class="table-row" data-href="{% url 'ctfpad:users-detail' member.id %}">
                     <td>
-                        <img width="25px" height="25px" src="{{member.avatar_url}}" title="{{member.username}}" class="rounded-circle">
+                        <img width="25px" height="25px" src="{{member.avatar_url}}" title="{{member.username}}" alt="avatar" class="rounded-circle">
                     </td>
                     <td>
                         <a href="{% url 'ctfpad:users-detail' member.id %}">{{member.username}}</a>

--- a/ctfpad/templates/ctfpad/stats/team.html
+++ b/ctfpad/templates/ctfpad/stats/team.html
@@ -67,6 +67,7 @@
             <table class="table table-sm table-hover">
                 <thead>
                 <tr>
+                    <th scope="col"></th>
                     <th scope="col">Name</th>
                     <th scope="col">Country</th>
                     <th scope="col">Status</th>
@@ -83,9 +84,12 @@
                 {% for member in team.members %}
                 <tr class="table-row" data-href="{% url 'ctfpad:users-detail' member.id %}">
                     <td>
+                        <img width="25px" height="25px" src="{{member.avatar_url}}" title="{{member.username}}" class="rounded-circle">
+                    </td>
+                    <td>
                         <a href="{% url 'ctfpad:users-detail' member.id %}">{{member.username}}</a>
                     </td>
-                    <td style="text-align: center;"><img height="20px" width="25px" src="{{member.country_flag_url}}" alt="{{member.country}}" class="rounded-circle"></td>
+                    <td style="text-align: center;"><img height="25px" width="25px" src="{{member.country_flag_url}}" alt="{{member.country}}" class="rounded-circle"></td>
                     <td>
                         {% if not member.is_active %}
                         Inactive

--- a/ctfpad/views/__init__.py
+++ b/ctfpad/views/__init__.py
@@ -97,7 +97,7 @@ def generate_stats(request: HttpRequest) -> HttpResponse:
         "most_solved": stats.solved_categories(),
         "last_year_stats": stats.last_year_stats(),
         "ranked_members": stats.get_ranking(),
-        "ranked_history": stats.get_ranking_history()
+        "ranked_history": stats.get_ranking_history(),
     }
     return render(request, "ctfpad/stats/detail.html", context)
 


### PR DESCRIPTION
Now pulls the user's avatar from gravatar (which is based on the user's email md5 hash). If gravatar doesn't have a match then we pull a colored image from https://eu.ui-avatars.com/ containing the first 2 letters of the user's username. Also you can now mouse-over the avatar image to display the full username (thx to the `title` attribute in the `<img` tag), so I removed the usernames from the podium since they looked a bit crooked anyway.

On the `Player Ranking` page I made the left hand side more compact by removing the second h5 header and card-body div, so now there's only one h5 the `All Time Ranking` h5, and the 2 tables are now inside the same card-body div. It works but tbh i have no idea what i'm doing when it comes to html/css.

