### PR TITLE
Fix charts

### DIFF
--- a/ctfpad/models.py
+++ b/ctfpad/models.py
@@ -560,17 +560,13 @@ class CtfStats:
     Statistic collection class
     """
 
-    def players_activity(self) -> dict:
+    def active_players(self) -> list:
+        """Return a list of active players (members with at least one solved challenge)
         """
-        Retrieve all the players activity (i.e. number of CTFs with at least
-        one solved challenge)
-        """
-        res = {}
-        active_players = Member.objects.filter(solved_challenges__isnull=False)
-        for player in active_players:
-            res[ player.username ] = Challenge.objects.filter(solvers__in = [player,]).distinct("ctf").count()
-        return res
-
+        members = Member.objects.filter(solved_challenges__isnull=False).distinct()
+        for member in members:
+            member.played_ctfs = Challenge.objects.filter(solvers__in = [member,])
+        return members
 
     def solved_categories(self) -> dict:
         """Return the total number of challenges solved per category

--- a/ctfpad/templates/ctfpad/challenges/detail.html
+++ b/ctfpad/templates/ctfpad/challenges/detail.html
@@ -7,23 +7,6 @@
 {% include 'snippets/messages.html' %}
 {% load ctfpad_filters %}
 
-{% if request.user.member.hedgedoc_password %}
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    fetch("{{hedgedoc_url}}/login", {
-      method: 'POST',
-      mode: 'no-cors',
-      cache: 'no-cache',
-      credentials: 'include',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded'},
-      body: "email={{request.user.member.hedgedoc_username}}&password={{request.user.member.hedgedoc_password}}"
-    }).then(data => {
-        document.getElementById("note_frame").contentWindow.location.replace("{{ challenge.note_url }}?both#");
-    });
-});
-</script>
-{% endif %}
-
 <div class="row">
     <div class="col-md-3">
         <div class="row">
@@ -224,6 +207,20 @@ document.addEventListener('DOMContentLoaded', function() {
     </div>
 </div>
 
+{% if request.user.member.hedgedoc_password %}
+<script>
+    fetch("{{hedgedoc_url}}/login", {
+        method: 'POST',
+        mode: 'no-cors',
+        cache: 'no-cache',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded'},
+        body: "email={{request.user.member.hedgedoc_username}}&password={{request.user.member.hedgedoc_password}}"
+    }).then(data => {
+        document.getElementById("note_frame").contentWindow.location.replace("{{ challenge.note_url }}?both#");
+    });
+</script>
+{% endif %}
 
 {% include 'snippets/quick_add_file.html' with challenge=challenge %}
 

--- a/ctfpad/templates/ctfpad/ctfs/detail_notes.html
+++ b/ctfpad/templates/ctfpad/ctfs/detail_notes.html
@@ -1,21 +1,3 @@
-{% if request.user.member.hedgedoc_password %}
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    fetch("{{hedgedoc_url}}/login", {
-      method: 'POST',
-      mode: 'no-cors',
-      cache: 'no-cache',
-      credentials: 'include',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded'},
-      body: "email={{request.user.member.hedgedoc_username}}&password={{request.user.member.hedgedoc_password}}"
-    }).then(data => {
-        document.getElementById("note_frame").contentWindow.location.replace("{{ ctf.note_url }}?both#");
-    });
-
-});
-</script>
-{% endif %}
-
 <div class="card card-body">
     <div class="row">
         <div class="embed-responsive embed-responsive-16by9">
@@ -29,3 +11,17 @@ document.addEventListener('DOMContentLoaded', function() {
         </div>
     </div>
 </div>
+{% if request.user.member.hedgedoc_password %}
+<script>
+    fetch("{{hedgedoc_url}}/login", {
+        method: 'POST',
+        mode: 'no-cors',
+        cache: 'no-cache',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded'},
+        body: "email={{request.user.member.hedgedoc_username}}&password={{request.user.member.hedgedoc_password}}"
+    }).then(data => {
+        document.getElementById("note_frame").contentWindow.location.replace("{{ ctf.note_url }}?both#");
+    });
+</script>
+{% endif %}

--- a/ctfpad/templates/ctfpad/stats/charts.html
+++ b/ctfpad/templates/ctfpad/stats/charts.html
@@ -5,38 +5,43 @@
             <script>
 new Chart(document.getElementById("chart1"),
 {
-	"type": "bar",
-	"data":
+	type: "bar",
+	data:
 	{
-		"labels": [
-            {% for player in player_ctf_count %}
-                "{{player}}",
+		labels: [
+            {% for member in active_players %}
+                "{{member.username}}",
             {% endfor %}
         ],
-		"datasets": [
-		{
-			"label": "Most active players*",
-			"data": [
-                {% for player, count in player_ctf_count.items %}
-                    {{count}},
-                {% endfor %}
-            ],
-			"fill": false,
-			"borderWidth": 1,
-            "backgroundColor": [{% for _ in player_ctf_count %}generate_random_color({{forloop.counter}}), {% endfor %}]
-		}]
+		datasets: [
+            {
+                data: [
+                    {% for member in active_players %}
+                        {{member.played_ctfs.count}},
+                    {% endfor %}
+                ],
+                fill: false,
+                borderWidth: 1,
+                backgroundColor: [{% for member in active_players %}generate_random_color({{forloop.counter}}), {% endfor %}]
+            },
+        ]
 	},
-	"options":
-	{
-		"scales":
-		{
-			"yAxes": [
-			{
-				"ticks":
-				{
-					"beginAtZero": true
-				}
-			}]
+	options: {
+        legend: {
+            display: false
+        },
+        title: {
+            display: true,
+            text: "Most active players*"
+        },
+		scales: {
+            yAxes: [
+                {
+                    ticks: {
+                        beginAtZero: true
+                    }
+                }
+            ]
 		}
 	}
 });
@@ -51,22 +56,27 @@ new Chart(document.getElementById("chart1"),
             <canvas id="chart2" width="33%" height="20%"></canvas>
             <script>
 new Chart(document.getElementById("chart2"), {
-    "type": "doughnut",
-    "data": {
-        "labels": [
+    type: "doughnut",
+    data: {
+        labels: [
             {% for solved in most_solved %}
                 "{{solved.category__name|upper}}",
             {% endfor %}
         ],
-        "datasets": [{
-            "label": "Most solved categories",
-            "data": [
+        datasets: [{
+            data: [
                 {% for solved in most_solved %}
                     {{solved.category__count|upper}},
                 {% endfor %}
             ],
-            "backgroundColor": [{% for _ in most_solved %}generate_random_color({{forloop.counter}}), {% endfor %}]
+            backgroundColor: [{% for _ in most_solved %}generate_random_color({{forloop.counter}}), {% endfor %}]
         }]
+    },
+    options: {
+        title: {
+            display: true,
+            text: "Most Solved Categories"
+        }
     }
 });
             </script>
@@ -79,22 +89,29 @@ new Chart(document.getElementById("chart2"), {
             <canvas id="chart3" width="33%" height="20%"></canvas>
             <script>
 new Chart(document.getElementById("chart3"), {
-    "type": "line",
-    "data": {
-        "labels": [
+    type: "line",
+    data: {
+        labels: [
             {% for month in last_year_stats reversed %}"{{month}}",{% endfor %}
         ],
-        "datasets": [{
-            "label": "Number of CTFs played for the last year",
-            "data": [
+        datasets: [{
+            data: [
                 {% for month, count in last_year_stats.items reversed %}{{count}},{% endfor %}
             ],
-            "fill": false,
-            "borderColor": "rgb(75, 192, 192)",
-            "lineTension": 0.1
+            fill: false,
+            borderColor: "rgb(75, 192, 192)",
+            lineTension: 0.1
         }]
     },
-    "options": {}
+    options: {
+        legend: {
+            display: false
+        },
+        title: {
+            display: true,
+            text: "Number of CTFs played for the last year"
+        }
+    }
 });
             </script>
         </div>

--- a/ctfpad/templates/ctfpad/stats/team.html
+++ b/ctfpad/templates/ctfpad/stats/team.html
@@ -1,9 +1,8 @@
 {% load static %}
 <div class="row">
     <div class="col-md-4">
-        <h5>{{team.name | upper}}</h5>
-		<hr>
 		<div class="card card-body">
+            <h5>{{team.name}}</h5>
             <ul class="list-group">
                 <li class="list-group-item list-group-item-action" style="text-align: center;">
                     {% if team.avatar %}
@@ -61,9 +60,8 @@
     </div>
 
     <div class="col-md-8">
-        <h5>Members</h5>
-        <hr>
         <div class="card card-body">
+            <h5>Members</h5>
             <table class="table table-sm table-hover">
                 <thead>
                 <tr>

--- a/ctfpad/templates/ctfpad/stats/timeline.html
+++ b/ctfpad/templates/ctfpad/stats/timeline.html
@@ -4,30 +4,28 @@
         <canvas id="timeline_chart"></canvas>
         <script>
 new Chart(document.getElementById("timeline_chart"), {
-    "type": "line",
-    "data": {
-        "labels": [
+    type: "line",
+    data: {
+        labels: [
             {% for ctf, _ in ranked_members.0.scored_percent_history %}
                 "{{ ctf.name }}",            
             {% endfor %}
         ],
-        "datasets": [
+        datasets: [
             {% for member in ranked_members %}
                 {
-                    "label": "{{ member.username }}",
-                    "data": [
+                    label: "{{ member.username }}",
+                    data: [
                         {% for _, accu in member.scored_percent_history %}{{ accu }}, {% endfor %}
                     ],
-                    "fill": false,
-                    "lineTension": 0,
-                    "borderColor": generate_random_color({{ forloop.counter }}),
+                    fill: false,
+                    lineTension: 0,
+                    borderColor: generate_random_color({{forloop.counter}}),
                 },
             {% endfor %}
         ]
     },
-    "options": {
-        
-    }
+    options: {}
 });
         </script>
     </div>

--- a/ctfpad/views/__init__.py
+++ b/ctfpad/views/__init__.py
@@ -93,7 +93,7 @@ def generate_stats(request: HttpRequest) -> HttpResponse:
 
     context = {
         "team": Team.objects.first(),
-        "player_ctf_count": stats.players_activity(),
+        "active_players": stats.active_players(),
         "most_solved": stats.solved_categories(),
         "last_year_stats": stats.last_year_stats(),
         "ranked_members": stats.get_ranking(),


### PR DESCRIPTION
* the title of the 2 cards on the `General` stats tab now show correctly
* the title of the 3 charts on the `Stats` stats tab now show correctly
* the `DOMContentLoaded` event handler is no longer necessary because the `fetch(../login)` call is now after the hedgedoc `<iframe>`