### PR TITLE
Use a LRU Cache implementation with a per-item TTL value

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-magic
 psycopg2-binary
 django-model-utils
 bleach
+cachetools


### PR DESCRIPTION
I did some testing on my local instance:
* without the `@lru_cache` decorator on `ctftime_fetch_ctfs()`, the `/ctfs/` page takes ~ `1000ms` to load
* with `@lru_cache`, page takes `300ms` to load

So we could either completely get rid of `@lru_cache` on that function, or we could have a TTL on the cached value.

Either way we can't keep having `@lru_cache` on a function with no args because it means CTFTime is only queried once (when the view is accessed for the first time), after that CTFTime is never checked again, so we could potentially miss CTFs that have been added to CTFTime afterwards or even if ctfpad isn't restarted for several months we'll actually run out of CTFs to import lol.

So it makes sense to cache the CTFTime response with a TTL, mostly because the function has no args.

The downside to my PR is that it adds the new `cachetools` dependency to `requirements.txt`. So if you prefer we could just use this:
```python
# stolen from https://realpython.com/lru-cache-python/#evicting-cache-entries-based-on-both-time-and-space
from functools import lru_cache, wraps
from datetime import datetime, timedelta
def timed_lru_cache(seconds: int, maxsize: int = 128):
    def wrapper_cache(func):
        func = lru_cache(maxsize=maxsize)(func)
        func.lifetime = timedelta(seconds=seconds)
        func.expiration = datetime.utcnow() + func.lifetime

        @wraps(func)
        def wrapped_func(*args, **kwargs):
            if datetime.utcnow() >= func.expiration:
                func.cache_clear()
                func.expiration = datetime.utcnow() + func.lifetime

            return func(*args, **kwargs)

        return wrapped_func

    return wrapper_cache
```
Alternatively we could also keep having `@lru_cache` if we always call `ctftime_fetch_ctfs()` with one argument. It could be `datetime.now().hour` for example. But this kinda feels like a hack.

Thoughts?