### PR TITLE
Fix static files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A webapp for managing CTFs by teams playing [CTFs](https://en.wikipedia.org/wiki
 
 ## Build
 
+### Docker
 
 For most people, this will suffice:
 
@@ -20,6 +21,14 @@ $ nano docker-compose.yml
 $ docker-compose up -d --build
 ```
 
+### Heroku
+
+Install and run it on Heroku (it's free!):
+
+```
+$ ./install-heroku.sh
+```
+
 ## Features
 
 A non-exhaustive list of features:
@@ -29,7 +38,7 @@ A non-exhaustive list of features:
  - Key-in-hands setup via [`docker-compose`](https://docs.docker.com/compose)
  - Fully built on top of [HedgeDoc](https://github.com/hedgedoc/hedgedoc): smart markdown note mechanism, with [tons of features](https://demo.hedgedoc.org/features)
  - Possibility to create and play private CTFs
- - Internal statistic system to track members' involment + basic ranking system
+ - Internal statistic system to track members' involment + team ranking
  - [Jitsi](https://meet.jit.si) integration: instantly jump on video chat with your team mate
  - CTFTime integration: import CTF (+ data) from CTFTime in 2 clicks
  - Dark mode (duh!)

--- a/ctfpad/templates/ctfpad/main.html
+++ b/ctfpad/templates/ctfpad/main.html
@@ -5,13 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 	<title>CTFPad</title>
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-	<link rel="stylesheet" type="text/css" href="{% static '/css/fontawesome/css/all.min.css' %}" />
-	<link rel="stylesheet" type="text/css" href="/static/css/main-{% theme_cookie %}.css"/>
-	<link rel="icon" type="image/png" sizes="16x16" href="{% static '/images/favicon.png'%}">
+	<link rel="stylesheet" type="text/css" href="{% static 'css/fontawesome/css/all.min.css' %}" />
+	<link rel="stylesheet" type="text/css" href="{% get_static_prefix %}css/main-{% theme_cookie %}.css"/>
+	<link rel="icon" type="image/png" sizes="16x16" href="{% static 'images/favicon.png'%}">
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.min.js"></script>
-	<link rel="stylesheet" type="text/css" href="{% static '/css/chart.css' %}"/>
-	<link rel="stylesheet" type="text/css" href="{% static '/css/podium.css' %} ">
-	<script src="{% static '/js/utils.js' %}"></script>
+	<link rel="stylesheet" type="text/css" href="{% static 'css/chart.css' %}"/>
+	<link rel="stylesheet" type="text/css" href="{% static 'css/podium.css' %} ">
+	<script src="{% static 'js/utils.js' %}"></script>
 </head>
 <body>
 	{% if request.user.is_authenticated %}

--- a/ctfpad/templates/ctfpad/shortcuts.html
+++ b/ctfpad/templates/ctfpad/shortcuts.html
@@ -43,5 +43,5 @@
         */
     };
 </script>
-<script src="{% static '/js/shortcuts.js' %}"></script>
+<script src="{% static 'js/shortcuts.js' %}"></script>
 

--- a/ctfpad/urls.py
+++ b/ctfpad/urls.py
@@ -12,7 +12,7 @@ app_name = "ctfpad"
 urlpatterns = [
     # /
     path("", views.index, name="home"),
-    path("favicon.ico", RedirectView.as_view(url=staticfiles_storage.url('static/images/favicon.ico'))),
+    path("favicon.ico", RedirectView.as_view(url=staticfiles_storage.url('images/favicon.png'))),
 
     # team
     ## create

--- a/ctftools/settings.py
+++ b/ctftools/settings.py
@@ -25,7 +25,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.getenv('CTFPAD_SECRET_KEY') or 'ow#8y081ih3nunjqh)u^ug)ln_$xri3-upt^e)7h)&l$05-7tf'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.getenv('DEBUG') or False
+DEBUG = os.getenv('DEBUG') in ['1', 'True', 'true']
 
 
 CTFPAD_HOSTNAME = os.getenv("CTFPAD_HOSTNAME") or "localhost"
@@ -56,6 +56,7 @@ SITE_ID = 1
 
 
 MIDDLEWARE = [
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -144,10 +145,14 @@ USE_TZ = False
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
+STATIC_ROOT = BASE_DIR / 'staticfiles'
 STATIC_URL = '/static/'
 STATICFILES_DIRS = [
     BASE_DIR / "static",
 ]
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+
+os.makedirs(STATIC_ROOT, exist_ok=True)
 
 MEDIA_URL   = "/uploads/"
 MEDIA_ROOT  = BASE_DIR / "uploads/"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,5 +12,6 @@ echo "DB setup: makemigrations..."
 echo "DB setup: migrate..."
 python3 manage.py makemigrations --noinput
 python3 manage.py migrate --noinput
+python3 manage.py collectstatic --noinput
 
 exec "$@"

--- a/install-heroku.sh
+++ b/install-heroku.sh
@@ -1,28 +1,42 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 echo 'Logging in to heroku'
 heroku login
 
+echo 'Creating the ctfpad and hedgedoc apps and a postgres db in the Europe region'
+
+CTFPAD_URL=$(heroku apps:create --region eu | cut -d' ' -f1)
+HEDGEDOC_URL=$(heroku apps:create --region eu | cut -d' ' -f1)
+WHITEBOARD_URL=$(heroku apps:create --region eu | cut -d' ' -f1)
+
+CTFPAD_NAME=$(echo $CTFPAD_URL | cut -d/ -f3 | cut -d. -f1)
+HEDGEDOC_NAME=$(echo $HEDGEDOC_URL | cut -d/ -f3 | cut -d. -f1)
+WHITEBOARD_NAME=$(echo $WHITEBOARD_URL | cut -d/ -f3 | cut -d. -f1)
+
+heroku addons:create -a $CTFPAD_NAME heroku-postgresql:hobby-dev
+DATABASE_URL=$(heroku config -a $CTFPAD_NAME -s | grep DATABASE_URL | cut -d\' -f2)
+
+
 echo 'Installing ctfpad'
-cd /tmp
-mkdir ctfpad && cd ctfpad
+cd $(mktemp -d)
 
 git clone https://github.com/hugsy/ctfpad .
 
-heroku apps:create ctfp4d
-heroku addons:create heroku-postgresql:hobby-dev
-eval $(heroku config -s | grep DATABASE_URL)
+DB=(`python -c "from urllib.parse import urlparse
+u = urlparse('$DATABASE_URL')
+print(u.username, u.password, u.hostname, u.port, u.path.strip('/'))"`)
 
-DB=$(python -c "from urllib.parse import urlparse;u=urlparse('$DATABASE_URL');print(u.username,u.password,u.hostname,u.port,u.path.strip('/'))")
-
-heroku config:set CTFPAD_HOSTNAME=ctfp4d.herokuapp.com
-heroku config:set CTFPAD_DB_USER=$(echo $DB | cut -d' ' -f1)
-heroku config:set CTFPAD_DB_PASSWORD=$(echo $DB | cut -d' ' -f2)
-heroku config:set CTFPAD_DB_HOST=$(echo $DB | cut -d' ' -f3)
-heroku config:set CTFPAD_DB_PORT=$(echo $DB | cut -d' ' -f4)
-heroku config:set CTFPAD_DB_NAME=$(echo $DB | cut -d' ' -f5)
-heroku config:set HEDGEDOC_URL=https://h3dgedoc.herokuapp.com
-heroku config:set CTFPAD_USE_SSL=0
+heroku config:set -a $CTFPAD_NAME CTFPAD_HOSTNAME=$(echo $CTFPAD_URL | cut -d/ -f3)
+heroku config:set -a $CTFPAD_NAME CTFPAD_PORT=443
+heroku config:set -a $CTFPAD_NAME CTFPAD_USE_SSL=0
+heroku config:set -a $CTFPAD_NAME CTFPAD_DB_USER=${DB[0]}
+heroku config:set -a $CTFPAD_NAME CTFPAD_DB_PASSWORD=${DB[1]}
+heroku config:set -a $CTFPAD_NAME CTFPAD_DB_HOST=${DB[2]}
+heroku config:set -a $CTFPAD_NAME CTFPAD_DB_PORT=${DB[3]}
+heroku config:set -a $CTFPAD_NAME CTFPAD_DB_NAME=${DB[4]}
+heroku config:set -a $CTFPAD_NAME CTFPAD_SECRET_KEY=$(openssl rand -base64 32)
+heroku config:set -a $CTFPAD_NAME HEDGEDOC_URL=${HEDGEDOC_URL%/}
+heroku config:set -a $CTFPAD_NAME WHITEBOARD_URL=${WHITEBOARD_URL%/}
 
 echo 'python-3.9.1' > runtime.txt
 
@@ -32,31 +46,33 @@ web: python manage.py runserver 0.0.0.0:$PORT --noreload
 EOF
 
 # uncomment to import previous db
-#ADDON=$(heroku pg:info | grep Add-on:| cut -d: -f2)
+#ADDON=$(heroku pg:info | grep Add-on: | cut -d: -f2)
 #heroku pg:push postgres://ctfpad:p4ssw0rd@localhost:5432/ctfpad $ADDON
 
-git push heroku master
+heroku git:remote -a $CTFPAD_NAME
+
+git checkout -b hero master
+git add Procfile runtime.txt
+git commit -a -m Heroku\ files
+git push heroku hero:master
+
 
 echo 'Installing hedgedoc'
-cd /tmp
-mkdir hedgedoc && cd hedgedoc
+cd $(mktemp -d)
+
 git clone https://github.com/hedgedoc/hedgedoc.git .
 git checkout -b fix 1.7.2
 
-heroku create h3dgedoc
+heroku config:set -a $HEDGEDOC_NAME CMD_DB_URL=$DATABASE_URL
+heroku config:set -a $HEDGEDOC_NAME CMD_DOMAIN=$(echo $HEDGEDOC_URL | cut -d/ -f3)
+heroku config:set -a $HEDGEDOC_NAME CMD_URL_ADDPORT=false
+heroku config:set -a $HEDGEDOC_NAME CMD_PROTOCOL_USESSL=true
+heroku config:set -a $HEDGEDOC_NAME CMD_ALLOW_ANONYMOUS=false
+heroku config:set -a $HEDGEDOC_NAME CMD_ALLOW_FREEURL=true
+heroku config:set -a $HEDGEDOC_NAME CMD_IMAGE_UPLOAD_TYPE=filesystem
+heroku config:set -a $HEDGEDOC_NAME CMD_COOKIE_POLICY=none
 
-heroku config:set DATABASE_URL=$DATABASE_URL
-heroku config:set CMD_DB_URL=$DATABASE_URL
-heroku config:set CMD_DOMAIN=h3dgedoc.herokuapp.com
-heroku config:set CMD_URL_ADDPORT=false
-heroku config:set CMD_PROTOCOL_USESSL=true
-heroku config:set CMD_ALLOW_ANONYMOUS=false
-heroku config:set CMD_ALLOW_FREEURL=true
-heroku config:set CMD_IMAGE_UPLOAD_TYPE=filesystem
-heroku config:set CMD_COOKIE_POLICY=none
-
-
-cat > bin/heroku <<'EOA'
+cat > bin/heroku << EOA
 #!/bin/bash
 
 set -e
@@ -92,10 +108,25 @@ cat << EOF > config.json
     }
   }
 }
-
 EOF
+
 EOA
+
+heroku git:remote -a $HEDGEDOC_NAME
 
 git commit -m fix bin/heroku
 git push heroku fix:master
-heroku logs --tail
+
+
+echo 'Installing whiteboard'
+cd $(mktemp -d)
+
+git clone https://github.com/cracker0dks/whiteboard .
+git checkout master
+
+heroku git:remote -a $WHITEBOARD_NAME
+
+git push heroku master
+
+
+echo "All done. Visit $CTFPAD_URL"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-magic
 psycopg2-binary
 django-model-utils
 bleach
+whitenoise


### PR DESCRIPTION
CTFPad can now run with `DEBUG` turned off.

Before it was always running with `settings.DEBUG` set to `True` due to passing the env var `DEBUG=0` in https://github.com/hugsy/ctfpad/blob/master/docker-compose.yml#L62 or in https://github.com/hugsy/ctfpad/blob/master/Dockerfile#L6 which makes the `settings.DEBUG` variable truthy at https://github.com/hugsy/ctfpad/blob/master/ctftools/settings.py#L28 because `DEBUG = os.getenv('DEBUG') or False` actually becomes `DEBUG='0'` and `bool('0') -> True` :)

As a result, static files were not working when turning off debug. This should be now all fixed up.