### PR TITLE
fix: correct path for excalidraw build repo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,1 @@
-src-repos
+external-repos

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
 
   excalidraw:
     build:
-      context: ./src-repos/excalidraw
+      context: ./external-repos/excalidraw
       target: production
     container_name: excalidraw
     networks:


### PR DESCRIPTION
Sorry, just noticed I forgot to rename the source repo for the build of local `excalidraw`, to match the folder created in the `Makefile`.