### PR TITLE
Fix link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ And if you can, consider [sponsoring me](https://github.com/hugsy/sponsors) - it
 ## Credits and Links
 
 - The world flag images are downloaded from https://flagpedia.net/
-- [CTFHub](https://github.com/StratumAuhuur/CTFHub): NodeJS project that is based on [`etherpad-lite`](https://yopad.eu) (no MarkDown support).
+- [CTFPad](https://github.com/StratumAuhuur/CTFPad): NodeJS project that is based on [`etherpad-lite`](https://yopad.eu) (no MarkDown support).


### PR DESCRIPTION
StratumAuhuur/CTFPad was renamed during replace

I was proposing the use of CTFHub when I noticed the StratumAuhuur/CTFPad was also replaced to CTFHub