### PR TITLE
Fix manual challenge create

### DIFF
--- a/ctfhub/forms.py
+++ b/ctfhub/forms.py
@@ -126,7 +126,6 @@ class ChallengeCreateForm(forms.ModelForm):
             "points",
             "description",
             "category",
-            "note_id",
             "ctf",
         ]
 


### PR DESCRIPTION
When attempting to manually create a challenge the user is presented with a form consisting of:

- Name
- Points
- Category
- Description

On submit the api returns:
"Error: note_id. This field is required"
There is no option for the user to supply a note_id.

This is a validation error. note_id has a default which will be used for new challenges.

This PR removes note_id from the validation for ChallengeCreateForm.