### PR TITLE
Bug: is_finished should return False for permanent CTFs

### DIFF
--- a/ctfhub/models.py
+++ b/ctfhub/models.py
@@ -276,7 +276,7 @@ class Ctf(TimeStampedModel):
             bool: _description_
         """
         if self.is_permanent:
-            return True
+            return False
         if not self.is_time_limited:
             raise AttributeError
 

--- a/ctfhub/tests/test_models.py
+++ b/ctfhub/tests/test_models.py
@@ -28,6 +28,7 @@ class TestMemberView(TestCase):
         assert not ctf.start_date and not ctf.end_date
         assert ctf.is_permanent
         assert not ctf.is_time_limited
+        assert not ctf.is_finished
 
         # both date => not permanent
         ctf.start_date = datetime.datetime(1970, 1, 1, 0, 0, 0)


### PR DESCRIPTION
If a CTF is permanent, is_finished should return `False`. 

This fixes https://github.com/hugsy/ctfhub/issues/92