### PR TITLE
Fix `.env.example`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,19 +26,14 @@ CTFHUB_DB_PASSWORD=1358127ce28271330b266cbf2ff556af13653fb5    # Change here
 #
 ## The FQDN of how web browsers should reach hedgedoc
 CTFHUB_HEDGEDOC_USESSL=false
-CTFHUB_HEDGEDOC_DOMAIN=localhost
+CTFHUB_HEDGEDOC_DOMAIN=hedgedoc
 CTFHUB_HEDGEDOC_PORT=3000
-CTFHUB_HEDGEDOC_PUBLIC_URL=http://${CTFHUB_HEDGEDOC_DOMAIN}:${CTFHUB_HEDGEDOC_PORT}
-
-## The FQDN of how ctfhub should reach hedgedoc - useful for docker-compose environments
-CTFHUB_HEDGEDOC_PRIVATE_URL=http://hedgedoc:3000
-
-## The values `CTFHUB_HEDGEDOC_PUBLIC_URL` can be identical if you're not using `docker-compose` or reverse proxy
+CTFHUB_HEDGEDOC_URL=http://${CTFHUB_HEDGEDOC_DOMAIN}:${CTFHUB_HEDGEDOC_PORT}
 
 #
 # CTFHub Email recovery feature
 #
-# Leave blank or customize below to enable the password recovery feature by email
+# Customize below to enable the password recovery feature by email
 CTFHUB_EMAIL_SERVER_HOST=''                                 # smtp.gmail.com or mailgun, or sendgrid etc.
 CTFHUB_EMAIL_SERVER_PORT=0
 CTFHUB_EMAIL_USERNAME=''

--- a/ctfhub/tests/test_helpers.py
+++ b/ctfhub/tests/test_helpers.py
@@ -36,7 +36,9 @@ class TestHelpers(TestCase):
                 assert isinstance(ctf["organizers"], list)
                 assert isinstance(ctf["onsite"], bool)
                 assert isinstance(ctf["description"], str)
-                assert isinstance(ctf["weight"], int) or isinstance(ctf["weight"], float)
+                assert isinstance(ctf["weight"], int) or isinstance(
+                    ctf["weight"], float
+                )
                 assert isinstance(ctf["title"], str)
                 assert isinstance(ctf["url"], str)
                 assert isinstance(ctf["is_votable_now"], bool)

--- a/ctfhub/tests/test_helpers.py
+++ b/ctfhub/tests/test_helpers.py
@@ -36,7 +36,7 @@ class TestHelpers(TestCase):
                 assert isinstance(ctf["organizers"], list)
                 assert isinstance(ctf["onsite"], bool)
                 assert isinstance(ctf["description"], str)
-                assert isinstance(ctf["weight"], float)
+                assert isinstance(ctf["weight"], int) or isinstance(ctf["weight"], float)
                 assert isinstance(ctf["title"], str)
                 assert isinstance(ctf["url"], str)
                 assert isinstance(ctf["is_votable_now"], bool)


### PR DESCRIPTION
Removed `CTFHUB_HEDGEDOC_PRIVATE_URL` and `CTFHUB_HEDGEDOC_PUBLIC_URL` from example .env file, since only  `CTFHUB_HEDGEDOC_URL`  exists now.

Fixes #98 